### PR TITLE
OTEL利用時のservice名が正しくwaitingroomとなるように修正

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -49,7 +49,9 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 )
 
 var secureCookie = securecookie.New(
@@ -285,10 +287,13 @@ func initTracer(ctx context.Context, otelAgentAddr string) (*sdktrace.TracerProv
 		return nil, err
 	}
 
+	resource := resource.NewWithAttributes(semconv.SchemaURL, semconv.ServiceNameKey.String("waitingroom"))
+
 	tp := sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithBatcher(exporter),
 		sdktrace.WithSpanProcessor(sdktrace.NewBatchSpanProcessor(exporter)),
+		sdktrace.WithResource(resource),
 	)
 	otel.SetTracerProvider(tp)
 	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}))


### PR DESCRIPTION
OTEL有効時にservice名が`unknown_service:waitingroom`になるのをsemconv.ServiceNameKeyを設定することで修正しました。

